### PR TITLE
solr-base-build.json is now called search-engine-base-build.json

### DIFF
--- a/openshift/settings.sh
+++ b/openshift/settings.sh
@@ -5,4 +5,4 @@ export GIT_REF="master"
 # The templates that should not have their GIT referances(uri and ref) over-ridden
 # Templates NOT in this list will have they GIT referances over-ridden
 # with the values of GIT_URI and GIT_REF
-export skip_git_overrides="schema-spy-build.json solr-base-build.json backup-build.json"
+export skip_git_overrides="schema-spy-build.json search-engine-base-build.json backup-build.json"


### PR DESCRIPTION
The search functionality has changed names since moving over.

I pointed at the error on build, @WadeBarnes clarified the fix.
