### PR TITLE
Update nodejs version in frontend-artifacts-build

### DIFF
--- a/openshift/templates/frontend/frontend-artifacts-build.json
+++ b/openshift/templates/frontend/frontend-artifacts-build.json
@@ -154,7 +154,7 @@
       "displayName": "Source Image Tag",
       "description": "The tag of the source image.",
       "required": true,
-      "value": "8"
+      "value": "10"
     },
     {
       "name": "THEME",


### PR DESCRIPTION
Node version bumped to `10`.

I tried using `12`, however I get into an erro bout not being able to authenticate to pull the image:
```
pulling image error : Get https://registry.redhat.io/v2/rhscl/nodejs-12-rhel7/manifests/sha256:645f1dfcf7e07de4d8101fae60f0275c68fa09209706edd4c94197f236c014d2:  unauthorized: Please login to the Red Hat Registry using your Customer Portal credentials. Further instructions can be found here: https://access.redhat.com/RegistryAuthentication
--
```

I have worked around this before by using the centOS-based node image, but this would require additional changes to the build configuration: I can make those if desirable, in the meantime this should meet our needs for building Angular apps.




