### PR TITLE
updated pull secret description

### DIFF
--- a/openshift/templates/frontend/frontend-build.yaml
+++ b/openshift/templates/frontend/frontend-build.yaml
@@ -99,7 +99,7 @@ parameters:
     required: true
     value: docker/Dockerfile
   - name: PULL_SECRET_NAME
-    displayName: Pull Secret Name
+    displayName: PULL_SECRET_NAME
     description: The name of the pull secret to use during the build.
     required: false
     value: artifactory-creds


### PR DESCRIPTION
The build config was getting flagged as a deployment config because it contained the word `Secret`. Changed the wording to ensure the build config does not get interpreted as a deployment 